### PR TITLE
Add known User-Agent browser name aliases

### DIFF
--- a/browserforge/headers/utils.py
+++ b/browserforge/headers/utils.py
@@ -12,13 +12,13 @@ def get_browser(user_agent: str) -> Optional[str]:
     """
     Determines the browser name from the User-Agent string.
     """
-    if 'Firefox' in user_agent:
+    if any(alias in user_agent for alias in ('Firefox', 'FxiOS')):
         return 'firefox'
-    elif 'Chrome' in user_agent:
+    elif any(alias in user_agent for alias in ('Chrome', 'CriOS')):
         return 'chrome'
     elif 'Safari' in user_agent:
         return 'safari'
-    elif 'Edge' in user_agent:
+    elif any(alias in user_agent for alias in ('Edge', 'EdgA', 'Edg', 'EdgiOS')):
         return 'edge'
     return None
 


### PR DESCRIPTION
Many User-Agent strings contain browser name in different form.
See [canonicaNames](https://github.com/apify/fingerprint-suite/blob/8c9c365bd17b3238ba616dc7815f73e703c5234d/packages/generator-networks-creator/src/generator-networks-creator.ts#L124)

Without accepting these browser name aliases the `HeaderGenerator` will often raise [ValueError](https://github.com/daijro/browserforge/blob/main/browserforge/headers/generator.py#L360) even though it generated valid User-Agent.


