### PR TITLE
Adjust _get_accept_language_header output to more closely match browsers

### DIFF
--- a/browserforge/headers/generator.py
+++ b/browserforge/headers/generator.py
@@ -423,8 +423,8 @@ class HeaderGenerator:
             str: Accept-Language header string.
         """
         # First locale does not include quality factor, q=1 is considered as implicit.
-        additional_locales = [f"{locale};q={0.9 - index * 0.1:.1f}" for index, locale in enumerate(locales[1:])]
-        return ','.join(locales[:1] + additional_locales)
+        additional_locales = [f'{locale};q={0.9 - index * 0.1:.1f}' for index, locale in enumerate(locales[1:])]
+        return ','.join((locales[0], *additional_locales))
 
     def _load_headers_order(self) -> Dict[str, List[str]]:
         """

--- a/browserforge/headers/generator.py
+++ b/browserforge/headers/generator.py
@@ -424,7 +424,7 @@ class HeaderGenerator:
         """
         # First locale does not include quality factor, q=1 is considered as implicit.
         additional_locales = [f"{locale};q={0.9 - index * 0.1:.1f}" for index, locale in enumerate(locales[1:])]
-        return ', '.join(locales[:1] + additional_locales)
+        return ','.join(locales[:1] + additional_locales)
 
     def _load_headers_order(self) -> Dict[str, List[str]]:
         """

--- a/browserforge/headers/generator.py
+++ b/browserforge/headers/generator.py
@@ -422,9 +422,9 @@ class HeaderGenerator:
         Returns:
             str: Accept-Language header string.
         """
-        return ', '.join(
-            f"{locale};q={1.0 - index * 0.1:.1f}" for index, locale in enumerate(locales)
-        )
+        # First locale does not include quality factor, q=1 is considered as implicit.
+        additional_locales = [f"{locale};q={0.9 - index * 0.1:.1f}" for index, locale in enumerate(locales[1:])]
+        return ', '.join(locales[:1] + additional_locales)
 
     def _load_headers_order(self) -> Dict[str, List[str]]:
         """


### PR DESCRIPTION
Accept-language quality value q=1 is considered implicit and usually is not mentioned.
As shown in examples [docs ](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language?utm_source=mozilla&utm_medium=devtools-netmonitor&utm_campaign=default) and can be verified with common browsers.

White space between different languages is optional and browsers usually do not use it. See following example calls for the difference:

Before change:
`HeaderGenerator()._get_accept_language_header(["en-US", "en"])` -> 'en-US;q=1.0, en;q=0.9'
`HeaderGenerator()._get_accept_language_header(["en-US"])` -> 'en-US;q=1.0'
After change:
`HeaderGenerator()._get_accept_language_header(["en-US", "en"])` -> 'en-US,en;q=0.9'
`HeaderGenerator()._get_accept_language_header(["en-US"])` -> 'en-US'