### PR TITLE
Add `generate-headers` CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,12 @@ Parameters:
 
 <hr width=50>
 
+### Command line usage
+
+Generate and print headers in a Curl-compatible format:
+
+    generate-headers
+
 ## Uninstall
 
 ```

--- a/browserforge/cli.py
+++ b/browserforge/cli.py
@@ -1,0 +1,9 @@
+from browserforge.headers import HeaderGenerator
+
+
+def main():
+    for k, v in HeaderGenerator().generate().items():
+        print(f"{k}: {v}")
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,6 @@ apify_fingerprint_datapoints = "*"
 
 [tool.poetry.extras]
 all = ["orjson"]
+
+[tool.poetry.scripts]
+generate-headers = "browserforge.cli:main"


### PR DESCRIPTION
It prints the headers in a Curl-compatible format, to be used like this:

    curl -H @<(generate-headers) ...